### PR TITLE
Stop the output channel interrupts whenever an error occurs

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,7 @@ import {
 	LanguageClient,
 	LanguageClientOptions,
 	ServerOptions,
+	RevealOutputChannelOn
 } from 'vscode-languageclient';
 
 let client: LanguageClient;
@@ -76,12 +77,15 @@ export function activate(context: ExtensionContext) {
 	// Options to control the language client
 	let clientOptions: LanguageClientOptions = {
 		// Register the server for plain text documents
-		documentSelector: [{scheme: 'file', language: 'ruby'}],
+		documentSelector: [{ scheme: 'file', language: 'ruby' }],
 		synchronize: {
 			// Notify the server about changes to relevant files in the workspace
 			fileEvents: workspace.createFileSystemWatcher('{**/*.rb,**/*.gemspec,**/Gemfile}')
-		}
+		},
+		outputChannelName: 'Sorbet Language Server',
+		revealOutputChannelOn: RevealOutputChannelOn.Never
 	};
+
 
 	// Create the language client and start the client.
 	client = new LanguageClient(


### PR DESCRIPTION
Currently if the sorbet server has an error for whatever reason:
 - it crashes
 - it doesn't have highlight information cause of `# typed: false`

The LSP output channel jumps up and takes focus. This means that sometimes files are completely unworkable. This uses the clientOption flag which means it doesn't take focus. I think this is more appropriate, and definitely less annoying for me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/danhuynhdev/sorbet-lsp/6)
<!-- Reviewable:end -->
