### PR TITLE
Allow to specify custom LSP options

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,11 @@
           "description": "Path to the bundle executable, defaults to 'bundle'",
           "default": "bundle",
           "scope": "resource"
+        },
+        "sorbet.commandOptions": {
+          "type": "string",
+          "default": "",
+          "description": "Sorbet command options. (If this is blank --enable-all-experimental-lsp-features is used)"
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,6 +64,7 @@ export function activate(context: ExtensionContext) {
 		const useBundler = vsconfig.useBundler;
 		const useWatchman = vsconfig.useWatchman;
 		const bundlerPath = vsconfig.bundlerPath || 'bundle';
+		const commandOptions = vsconfig.commandOptions.trim();
 
 		if (useBundler) {
 			cmd = cmd.concat([bundlerPath, 'exec', 'srb']);
@@ -71,7 +72,13 @@ export function activate(context: ExtensionContext) {
 			cmd.push(commandPath);
 		}
 
-		cmd = cmd.concat(['tc', '--lsp', '--enable-all-experimental-lsp-features']);
+		cmd = cmd.concat(['tc', '--lsp']);
+
+		if (commandOptions) {
+			cmd.push(commandOptions);
+		} else {
+			cmd.push('--enable-all-experimental-lsp-features');
+		}
 
 		if (!useWatchman) {
 			cmd.push('--disable-watchman');


### PR DESCRIPTION
Add `sorbet.commandOptions` configuration option to fine-tune the LSP server 
This can be used to, for example, hide symbols or disallow other options that are enabled with the `--enable-all-experimental-lsp-features` 